### PR TITLE
Add support for using modern smbus-cffi (0.4.1+)

### DIFF
--- a/Adafruit_LED_Backpack/HT16K33.py
+++ b/Adafruit_LED_Backpack/HT16K33.py
@@ -49,7 +49,7 @@ class HT16K33(object):
 	def begin(self):
 		"""Initialize driver with LEDs enabled and all turned off."""
 		# Turn on the oscillator.
-		self._device.writeList(HT16K33_SYSTEM_SETUP | HT16K33_OSCILLATOR, [])
+		self._device.writeList(HT16K33_SYSTEM_SETUP | HT16K33_OSCILLATOR, [0x00])
 		# Turn display on with no blinking.
 		self.set_blink(HT16K33_BLINK_OFF)
 		# Set display to full brightness.
@@ -63,7 +63,7 @@ class HT16K33(object):
 		if frequency not in [HT16K33_BLINK_OFF, HT16K33_BLINK_2HZ, 
 							 HT16K33_BLINK_1HZ, HT16K33_BLINK_HALFHZ]:
 			raise ValueError('Frequency must be one of HT16K33_BLINK_OFF, HT16K33_BLINK_2HZ, HT16K33_BLINK_1HZ, or HT16K33_BLINK_HALFHZ.')
-		self._device.writeList(HT16K33_BLINK_CMD | HT16K33_BLINK_DISPLAYON | frequency, [])
+		self._device.writeList(HT16K33_BLINK_CMD | HT16K33_BLINK_DISPLAYON | frequency, [0x00])
 
 	def set_brightness(self, brightness):
 		"""Set brightness of entire display to specified value (16 levels, from
@@ -71,7 +71,7 @@ class HT16K33(object):
 		"""
 		if brightness < 0 or brightness > 15:
 			raise ValueError('Brightness must be a value of 0 to 15.')
-		self._device.writeList(HT16K33_CMD_BRIGHTNESS | brightness, [])
+		self._device.writeList(HT16K33_CMD_BRIGHTNESS | brightness, [0x00])
 
 	def set_led(self, led, value):
 		"""Sets specified LED (value of 0 to 127) to the specified value, 0/False 


### PR DESCRIPTION
While working on a project with an RPi and Adafruit 7 segment displays I found that this library would not work with a modern version of smbus-cffi. Validation was added to smbus-cffi [around 0.4.1](https://github.com/bivab/smbus-cffi/commit/42ce472ed6bcc0c4f69dc8c6419723276d63ce7a) that requires the value portion of calls to `write_i2c_block_data` to contain at least one integer. HT16K33 makes calls to this method indirectly via Adafruit_GPIO.I2C through the `writeList` method, but passes an empty list, causing the exception below. This PR switches from passing the empty list to passing a list with a single `0x00` value, getting around the validation and allowing the displays function as desired.

An alternative solution could have been to switch from using writeList to write8 or similar, but either way a value should be passed.

```
Traceback (most recent call last):
  File "/home/gerad/src/saccharo-bitwave/bin/bitwave", line 48, in main
    config = Configuration(config_path=args['--config'])
  File "/home/gerad/src/saccharo-bitwave/bitwave/config.py", line 122, in __init__
    self._load_displays(config['displays'])
  File "/home/gerad/src/saccharo-bitwave/bitwave/config.py", line 156, in _load_displays
    address=display_address, label=display)
  File "/home/gerad/src/saccharo-bitwave/bitwave/display.py", line 23, in __init__
    self.begin()
  File "/home/gerad/src/py/src/adafruit-led-backpack/Adafruit_LED_Backpack/HT16K33.py", line 52, in begin
    self._device.writeList(HT16K33_SYSTEM_SETUP | HT16K33_OSCILLATOR, [])
  File "/home/gerad/src/py/src/adafruit-gpio/Adafruit_GPIO/I2C.py", line 102, in writeList
    self._bus.write_i2c_block_data(self._address, register, data)
  File "/home/gerad/src/py/local/lib/python2.7/site-packages/smbus/util.py", line 59, in validator
    return fn(*args, **kwdefaults)
  File "/home/gerad/src/py/local/lib/python2.7/site-packages/smbus/smbus.py", line 269, in write_i2c_block_data
    list_to_smbus_data(data, vals)
  File "/home/gerad/src/py/local/lib/python2.7/site-packages/smbus/smbus.py", line 300, in list_to_smbus_data
    "but not more than %d integers" % block_max)
OverflowError: Third argument must be a list of at least one, but not more than 32 integers
```
