### PR TITLE
Adding suspend/resume function to turn display off/on

### DIFF
--- a/Adafruit_LED_Backpack/HT16K33.py
+++ b/Adafruit_LED_Backpack/HT16K33.py
@@ -45,15 +45,25 @@ class HT16K33(object):
 			i2c = I2C
 		self._device = i2c.get_i2c_device(address, **kwargs)
 		self.buffer = bytearray([0]*16)
+                self._suspended = True
 
 	def begin(self):
 		"""Initialize driver with LEDs enabled and all turned off."""
 		# Turn on the oscillator.
 		self._device.writeList(HT16K33_SYSTEM_SETUP | HT16K33_OSCILLATOR, [])
+                self._suspended = False
 		# Turn display on with no blinking.
 		self.set_blink(HT16K33_BLINK_OFF)
 		# Set display to full brightness.
 		self.set_brightness(15)
+
+        def suspend(self):
+		self._device.writeList(HT16K33_SYSTEM_SETUP, [0x00])
+                self._suspended = True
+
+        def resume(self):
+		self._device.writeList(HT16K33_SYSTEM_SETUP | HT16K33_OSCILLATOR, [0x00])
+                self._suspended = False
 
 	def set_blink(self, frequency):
 		"""Blink display at specified frequency.  Note that frequency must be a
@@ -90,6 +100,8 @@ class HT16K33(object):
 			self.buffer[pos] |= (1 << offset)
 
 	def write_display(self):
+                if self._suspended:
+                    self.resume()
 		"""Write display buffer to display hardware."""
 		for i, value in enumerate(self.buffer):
 			self._device.write8(i, value)


### PR DESCRIPTION
I needed a function to turn the display off after a bit and resume it on user activity.
Best way to do this seems to be by turning the oscillator off and there was no function for this.
I added suspend/resume functions to do this and an _suspended value so that write_display will auto-resume the display if it's suspended.