### PR TITLE
Fix for justification in print_number_str in SevenSegment.py

### DIFF
--- a/Adafruit_LED_Backpack/HT16K33.py
+++ b/Adafruit_LED_Backpack/HT16K33.py
@@ -45,15 +45,25 @@ class HT16K33(object):
 			i2c = I2C
 		self._device = i2c.get_i2c_device(address, **kwargs)
 		self.buffer = bytearray([0]*16)
+                self._suspended = True
 
 	def begin(self):
 		"""Initialize driver with LEDs enabled and all turned off."""
 		# Turn on the oscillator.
 		self._device.writeList(HT16K33_SYSTEM_SETUP | HT16K33_OSCILLATOR, [])
+                self._suspended = False
 		# Turn display on with no blinking.
 		self.set_blink(HT16K33_BLINK_OFF)
 		# Set display to full brightness.
 		self.set_brightness(15)
+
+        def suspend(self):
+		self._device.writeList(HT16K33_SYSTEM_SETUP, [0x00])
+                self._suspended = True
+
+        def resume(self):
+		self._device.writeList(HT16K33_SYSTEM_SETUP | HT16K33_OSCILLATOR, [0x00])
+                self._suspended = False
 
 	def set_blink(self, frequency):
 		"""Blink display at specified frequency.  Note that frequency must be a
@@ -90,6 +100,8 @@ class HT16K33(object):
 			self.buffer[pos] |= (1 << offset)
 
 	def write_display(self):
+                if self._suspended:
+                    self.resume()
 		"""Write display buffer to display hardware."""
 		for i, value in enumerate(self.buffer):
 			self._device.write8(i, value)

--- a/Adafruit_LED_Backpack/SevenSegment.py
+++ b/Adafruit_LED_Backpack/SevenSegment.py
@@ -176,8 +176,13 @@ class SevenSegment(HT16K33.HT16K33):
 		if length > 4:
 			self.print_number_str('----')
 			return
-		# Calculcate starting position of digits based on justification.
-		pos = (4-length) if justify_right else 0
+		# Add spaces based on justification
+		pos = 0
+		if length < 4:
+			if justify_right:
+				value = '%s%s' % (' ' * (4 - length), value)
+			else:
+				value = '%s%s' % (value, ' ' * (4 - length))
 		# Go through each character and print it on the display.
 		for i, ch in enumerate(value):
 			if ch == '.':


### PR DESCRIPTION
The way print_number_str is now it can leave digits behind if you go from a bigger string to a smaller one.
For example consider running the following two commands:
```
print_number_str(22)
print_number_str(1)
```
The expected result would be that the display would show "1", however, due to the way justification is done it shows "21"
This fix changes the way justification is done so that instead of just starting at a particular position for right justification it pads the string with spaces on either the left or right based on the justify_right argument.


