### PR TITLE
Fix for justification in print_number_str in SevenSegment.py 

### DIFF
--- a/Adafruit_LED_Backpack/SevenSegment.py
+++ b/Adafruit_LED_Backpack/SevenSegment.py
@@ -176,8 +176,13 @@ class SevenSegment(HT16K33.HT16K33):
 		if length > 4:
 			self.print_number_str('----')
 			return
-		# Calculcate starting position of digits based on justification.
-		pos = (4-length) if justify_right else 0
+		# Add spaces based on justification
+		pos = 0
+		if length < 4:
+			if justify_right:
+				value = '%s%s' % (' ' * (4 - length), value)
+			else:
+				value = '%s%s' % (value, ' ' * (4 - length))
 		# Go through each character and print it on the display.
 		for i, ch in enumerate(value):
 			if ch == '.':


### PR DESCRIPTION
The way print_number_str is now it can leave digits behind if you go from a bigger string to a smaller one.
For example consider running the following two commands:

print_number_str(22)
print_number_str(1)
The expected result would be that the display would show "1", however, due to the way justification is done it shows "21"
This fix changes the way justification is done so that instead of just starting at a particular position for right justification it pads the string with spaces on either the left or right based on the justify_right argument.
