### PR TITLE
Fix for print_number_str

### DIFF
--- a/Adafruit_LED_Backpack/SevenSegment.py
+++ b/Adafruit_LED_Backpack/SevenSegment.py
@@ -176,9 +176,11 @@ class SevenSegment(HT16K33.HT16K33):
         if length > 4:
             self.print_number_str('----')
             return
-        # Calculcate starting position of digits based on justification.
-        pos = (4-length) if justify_right else 0
+        # pad the digits with blanks
+        blanks = " " * (4 - length)
+        value = blanks+value if justify_right else value+blanks
         # Go through each character and print it on the display.
+        pos = 0
         for i, ch in enumerate(value):
             if ch == '.':
                 # Print decimal points on the previous digit.


### PR DESCRIPTION
print_number_str would cause digit 'artifacts' if used to display some
number of digits, then used to display less digits in a following cycle.
The 'extra' digits would not be 'cleared'.

This fix pads the input string with spaces (based on justify_right
parameter) in order to push a blank digit to the buffer. This way, all 4
digit positions will be affected and there will be no artifacts.


Code to test:

from Adafruit_LED_Backpack import SevenSegment
segment = SevenSegment.SevenSegment(address=0x70)
segment.begin()
segment.clear()
print_number_str("100.0")
segment.write_display()
time.sleep(2)
print_number_str("99.9")
segment.write_display()

With the current bug, the display will read as 199.9, which is not desired.
With this fix, it will read correctly.