### PR TITLE
speed up writing to the display by using writeList

### DIFF
--- a/Adafruit_LED_Backpack/HT16K33.py
+++ b/Adafruit_LED_Backpack/HT16K33.py
@@ -92,8 +92,7 @@ class HT16K33(object):
 
     def write_display(self):
         """Write display buffer to display hardware."""
-        for i, value in enumerate(self.buffer):
-            self._device.write8(i, value)
+        self._device.writeList(0, self.buffer)
 
     def clear(self):
         """Clear contents of display buffer."""


### PR DESCRIPTION
By replacing the loop which sends the data to the display row by row, use writeList to send it in one go. This speeds up updating the display significantly on my Raspberry Pi Zero using Python 3.

This is tested with the bicolor 8x8 matrices.