### PR TITLE
Fix commented-out BicolorMatrix8x8 code sample

### DIFF
--- a/examples/bicolor_matrix8x8_test.py
+++ b/examples/bicolor_matrix8x8_test.py
@@ -29,7 +29,7 @@ from Adafruit_LED_Backpack import BicolorMatrix8x8
 display = BicolorMatrix8x8.BicolorMatrix8x8()
 
 # Alternatively, create a display with a specific I2C address and/or bus.
-# display = Matrix8x8.Matrix8x8(address=0x74, busnum=1)
+# display = BicolorMatrix8x8.BicolorMatrix8x8(address=0x74, busnum=1)
 
 # Initialize the display. Must be called once before using the display.
 display.begin()


### PR DESCRIPTION
In file `examples/bicolor_matrix8x8_test.py`, the comment that says how to set the bus number and address appears to have been copy-pasted from another example script, and references the wrong class.

This change fixes it.