### PR TITLE
Add parens around print call to make it py3 compatible.

### DIFF
--- a/examples/ex_7segment_clock.py
+++ b/examples/ex_7segment_clock.py
@@ -13,7 +13,7 @@ segment = SevenSegment.SevenSegment(address=0x70)
 # Initialize the display. Must be called once before using the display.
 segment.begin()
 
-print "Press CTRL+Z to exit"
+print("Press CTRL+Z to exit")
 
 # Continually update the time on a 4 char, 7-segment display
 while(True):


### PR DESCRIPTION
Before this change, this example did not work when run under Python 3
because `print` was being used as a keyword rather than a function call:
`print()`.