### PR TITLE
Add comment about busnum to use on BeagleBone

### DIFF
--- a/examples/alphanum4_test.py
+++ b/examples/alphanum4_test.py
@@ -29,6 +29,9 @@ display = AlphaNum4.AlphaNum4()
 # Alternatively, create a display with a specific I2C address and/or bus.
 # display = AlphaNum4.AlphaNum4(address=0x74, busnum=1)
 
+# On BeagleBone, try busnum=2 if IOError occurs with busnum=1
+# display = AlphaNum4.AlphaNum4(address=0x74, busnum=2)
+
 # Initialize the display. Must be called once before using the display.
 display.begin()
 

--- a/examples/bicolor_bargraph24_test.py
+++ b/examples/bicolor_bargraph24_test.py
@@ -29,6 +29,9 @@ display = BicolorBargraph24.BicolorBargraph24()
 # Alternatively, create a display with a specific I2C address and/or bus.
 # display = BicolorBargraph24.BicolorBargraph24(address=0x74, busnum=1)
 
+# On BeagleBone, try busnum=2 if IOError occurs with busnum=1
+# display = BicolorBargraph24.BicolorBargraph24(address=0x74, busnum=2)
+
 # Initialize the display. Must be called once before using the display.
 display.begin()
 

--- a/examples/bicolor_matrix8x8_test.py
+++ b/examples/bicolor_matrix8x8_test.py
@@ -31,6 +31,9 @@ display = BicolorMatrix8x8.BicolorMatrix8x8()
 # Alternatively, create a display with a specific I2C address and/or bus.
 # display = BicolorMatrix8x8.BicolorMatrix8x8(address=0x74, busnum=1)
 
+# On BeagleBone, try busnum=2 if IOError occurs with busnum=1
+# display = BicolorMatrix8x8.BicolorMatrix8x8(address=0x74, busnum=2)
+
 # Initialize the display. Must be called once before using the display.
 display.begin()
 

--- a/examples/matrix8x16_test.py
+++ b/examples/matrix8x16_test.py
@@ -33,6 +33,9 @@ display = Matrix8x16.Matrix8x16()
 # Alternatively, create a display with a specific I2C address and/or bus.
 # display = Matrix8x16.Matrix8x16(address=0x74, busnum=1)
 
+# On BeagleBone, try busnum=2 if IOError occurs with busnum=1
+# display = Matrix8x16.Matrix8x16(address=0x74, busnum=2)
+
 # Initialize the display. Must be called once before using the display.
 display.begin()
 

--- a/examples/matrix8x8_test.py
+++ b/examples/matrix8x8_test.py
@@ -32,6 +32,9 @@ display = Matrix8x8.Matrix8x8()
 # Alternatively, create a display with a specific I2C address and/or bus.
 # display = Matrix8x8.Matrix8x8(address=0x74, busnum=1)
 
+# On BeagleBone, try busnum=2 if IOError occurs with busnum=1
+# display = Matrix8x8.Matrix8x8(address=0x74, busnum=2)
+
 # Initialize the display. Must be called once before using the display.
 display.begin()
 

--- a/examples/sevensegment_test.py
+++ b/examples/sevensegment_test.py
@@ -29,6 +29,9 @@ display = SevenSegment.SevenSegment()
 # Alternatively, create a display with a specific I2C address and/or bus.
 # display = SevenSegment.SevenSegment(address=0x74, busnum=1)
 
+# On BeagleBone, try busnum=2 if IOError occurs with busnum=1
+# display = SevenSegment.SevenSegment(address=0x74, busnum=2)
+
 # Initialize the display. Must be called once before using the display.
 display.begin()
 


### PR DESCRIPTION
On BeagleBone, try `busnum=2` if IOError occurs with `busnum=1`

This error may occur when busnum is incorrect:
`IOError: [Errno 16] Device or resource busy`

Refer to this Adafruit Forum issue for more information:
[**LED Backpack not working on beaglebone black with debian**](https://forums.adafruit.com/viewtopic.php?f=49&t=140344)